### PR TITLE
Add Neovim debugging support for Go, JavaScript, and Jest

### DIFF
--- a/.config/nvim/nvim-pack-lock.json
+++ b/.config/nvim/nvim-pack-lock.json
@@ -93,6 +93,10 @@
       "rev": "b4421153ead5d726603b02743ea40cf26a51ed5f",
       "src": "https://github.com/leoluz/nvim-dap-go"
     },
+    "nvim-dap-virtual-text": {
+      "rev": "fbdb48c2ed45f4a8293d0d483f7730d24467ccb6",
+      "src": "https://github.com/theHamsta/nvim-dap-virtual-text"
+    },
     "nvim-lint": {
       "rev": "eab58b48eb11d7745c11c505e0f3057165902461",
       "src": "https://github.com/mfussenegger/nvim-lint"

--- a/.config/nvim/nvim-pack-lock.json
+++ b/.config/nvim/nvim-pack-lock.json
@@ -21,6 +21,10 @@
       "rev": "ad7e729e9a6348f7da482be0271d452dbc4c8e2c",
       "src": "https://github.com/zbirenbaum/copilot.lua"
     },
+    "delve": {
+      "rev": "558194cbdcce0dba1303d71e07747c72533483a5",
+      "src": "https://github.com/go-delve/delve"
+    },
     "diffview.nvim": {
       "rev": "4516612fe98ff56ae0415a259ff6361a89419b0a",
       "src": "https://github.com/sindrets/diffview.nvim"
@@ -84,6 +88,10 @@
     "nvim-dap": {
       "rev": "9e848e09a697ee95302a3ef2dd43fd6eb709e570",
       "src": "https://github.com/mfussenegger/nvim-dap"
+    },
+    "nvim-dap-go": {
+      "rev": "b4421153ead5d726603b02743ea40cf26a51ed5f",
+      "src": "https://github.com/leoluz/nvim-dap-go"
     },
     "nvim-lint": {
       "rev": "eab58b48eb11d7745c11c505e0f3057165902461",

--- a/.config/nvim/nvim-pack-lock.json
+++ b/.config/nvim/nvim-pack-lock.json
@@ -81,6 +81,10 @@
       "rev": "a065833f35a3a7cc3ef137ac88b5381da2ba302e",
       "src": "https://github.com/norcalli/nvim-colorizer.lua"
     },
+    "nvim-dap": {
+      "rev": "9e848e09a697ee95302a3ef2dd43fd6eb709e570",
+      "src": "https://github.com/mfussenegger/nvim-dap"
+    },
     "nvim-lint": {
       "rev": "eab58b48eb11d7745c11c505e0f3057165902461",
       "src": "https://github.com/mfussenegger/nvim-lint"

--- a/.config/nvim/nvim-pack-lock.json
+++ b/.config/nvim/nvim-pack-lock.json
@@ -97,6 +97,10 @@
       "rev": "fbdb48c2ed45f4a8293d0d483f7730d24467ccb6",
       "src": "https://github.com/theHamsta/nvim-dap-virtual-text"
     },
+    "nvim-dap-vscode-js": {
+      "rev": "03bd29672d7fab5e515fc8469b7d07cc5994bbf6",
+      "src": "https://github.com/mxsdev/nvim-dap-vscode-js"
+    },
     "nvim-lint": {
       "rev": "eab58b48eb11d7745c11c505e0f3057165902461",
       "src": "https://github.com/mfussenegger/nvim-lint"

--- a/.config/nvim/nvim-pack-lock.json
+++ b/.config/nvim/nvim-pack-lock.json
@@ -93,6 +93,10 @@
       "rev": "b4421153ead5d726603b02743ea40cf26a51ed5f",
       "src": "https://github.com/leoluz/nvim-dap-go"
     },
+    "nvim-dap-ui": {
+      "rev": "1a66cabaa4a4da0be107d5eda6d57242f0fe7e49",
+      "src": "https://github.com/rcarriga/nvim-dap-ui"
+    },
     "nvim-dap-virtual-text": {
       "rev": "fbdb48c2ed45f4a8293d0d483f7730d24467ccb6",
       "src": "https://github.com/theHamsta/nvim-dap-virtual-text"
@@ -112,6 +116,10 @@
     "nvim-lspconfig": {
       "rev": "4b7fbaa239c5db6b36f424a4521ca9f1a401be33",
       "src": "https://www.github.com/neovim/nvim-lspconfig"
+    },
+    "nvim-nio": {
+      "rev": "21f5324bfac14e22ba26553caf69ec76ae8a7662",
+      "src": "https://github.com/nvim-neotest/nvim-nio"
     },
     "nvim-treesitter": {
       "rev": "4916d6592ede8c07973490d9322f187e07dfefac",

--- a/.config/nvim/plugin/dap-go.lua
+++ b/.config/nvim/plugin/dap-go.lua
@@ -1,0 +1,13 @@
+vim.pack.add({
+	"https://github.com/mfussenegger/nvim-dap",
+	"https://github.com/leoluz/nvim-dap-go",
+})
+
+
+require("dap-go").setup({
+	delve = {
+		path = "dlv",
+		initialize_timeout_sec = 20,
+	},
+	-- optional: use a dedicated debug window layout later
+})

--- a/.config/nvim/plugin/dap-js.lua
+++ b/.config/nvim/plugin/dap-js.lua
@@ -1,0 +1,80 @@
+vim.pack.add({
+	"https://github.com/mfussenegger/nvim-dap",
+})
+
+local dap = require("dap")
+local js_debug_server = vim.fn.stdpath("data")
+	.. "/mason/packages/js-debug-adapter/js-debug/src/dapDebugServer.js"
+
+local function file_dirname()
+	return vim.fn.expand("%:p:h")
+end
+
+for _, adapter in ipairs({ "pwa-node", "node-terminal" }) do
+	dap.adapters[adapter] = {
+		type = "server",
+		host = "127.0.0.1",
+		port = "${port}",
+		executable = {
+			command = "node",
+			args = { js_debug_server, "${port}", "127.0.0.1" },
+		},
+	}
+end
+
+local node_configs = {
+	{
+		type = "pwa-node",
+		request = "launch",
+		name = "Launch current file",
+		program = "${file}",
+		cwd = "${workspaceFolder}",
+		sourceMaps = true,
+		protocol = "inspector",
+		console = "integratedTerminal",
+	},
+	{
+		type = "pwa-node",
+		request = "launch",
+		name = "Launch current file from file directory",
+		program = "${file}",
+		cwd = file_dirname,
+		sourceMaps = true,
+		protocol = "inspector",
+		console = "integratedTerminal",
+	},
+	{
+		type = "pwa-node",
+		request = "attach",
+		name = "Attach to Node process",
+		processId = require("dap.utils").pick_process,
+		cwd = "${workspaceFolder}",
+		sourceMaps = true,
+		protocol = "inspector",
+	},
+	{
+		type = "pwa-node",
+		request = "launch",
+		name = "Debug Jest current file",
+		runtimeExecutable = "node",
+		runtimeArgs = {
+			"./node_modules/.bin/jest",
+			"${file}",
+			"--runInBand",
+		},
+		cwd = "${workspaceFolder}",
+		console = "integratedTerminal",
+		sourceMaps = true,
+	},
+	{
+		type = "node-terminal",
+		request = "launch",
+		name = "Run npm start",
+		command = "npm start",
+		cwd = "${workspaceFolder}",
+	},
+}
+
+for _, language in ipairs({ "javascript", "typescript", "javascriptreact", "typescriptreact" }) do
+	dap.configurations[language] = node_configs
+end

--- a/.config/nvim/plugin/dap-ui.lua
+++ b/.config/nvim/plugin/dap-ui.lua
@@ -1,0 +1,47 @@
+vim.pack.add({
+	"https://github.com/rcarriga/nvim-dap-ui",
+	"https://github.com/nvim-neotest/nvim-nio",
+})
+
+local dap = require("dap")
+local dapui = require("dapui")
+
+dapui.setup({
+	layouts = {
+		{
+			elements = {
+				{ id = "scopes", size = 0.75 },
+				{ id = "breakpoints", size = 0.25 },
+			},
+			size = 40,
+			position = "left",
+		},
+		{
+			elements = {
+				{ id = "repl", size = 0.5 },
+				{ id = "console", size = 0.5 },
+			},
+			size = 10,
+			position = "bottom",
+		},
+	},
+	floating = {
+		border = "rounded",
+	},
+})
+
+vim.keymap.set("n", "<leader>du", dapui.toggle, { desc = "DAP: Toggle UI", silent = true })
+vim.keymap.set("n", "<leader>de", dapui.eval, { desc = "DAP: Evaluate expression", silent = true })
+vim.keymap.set("v", "<leader>de", dapui.eval, { desc = "DAP: Evaluate selection", silent = true })
+
+dap.listeners.after.event_initialized["dapui_config"] = function()
+	dapui.open()
+end
+
+dap.listeners.before.event_terminated["dapui_config"] = function()
+	dapui.close()
+end
+
+dap.listeners.before.event_exited["dapui_config"] = function()
+	dapui.close()
+end

--- a/.config/nvim/plugin/dap-virtual-text.lua
+++ b/.config/nvim/plugin/dap-virtual-text.lua
@@ -1,0 +1,15 @@
+vim.pack.add({
+	"https://github.com/theHamsta/nvim-dap-virtual-text",
+})
+
+require("nvim-dap-virtual-text").setup({
+	enabled = true,
+	enabled_commands = true,
+	highlight_changed_variables = true,
+	highlight_new_as_changed = false,
+	show_stop_reason = true,
+	commented = true,
+	only_first_definition = true,
+	all_references = false,
+	clear_on_continue = false,
+})

--- a/.config/nvim/plugin/dap.lua
+++ b/.config/nvim/plugin/dap.lua
@@ -43,7 +43,7 @@ local function map(lhs, rhs, desc)
 	vim.keymap.set("n", lhs, rhs, { desc = "DAP: " .. desc, silent = true })
 end
 
-map("<leader>dc", dap.continue, "Continue")
+map("<leader>dc", dap.continue, "Start/Continue")
 map("<leader>dt", dap.terminate, "Terminate")
 map("<leader>do", dap.step_over, "Step over")
 map("<leader>di", dap.step_into, "Step into")

--- a/.config/nvim/plugin/dap.lua
+++ b/.config/nvim/plugin/dap.lua
@@ -1,0 +1,59 @@
+vim.pack.add({
+	"https://github.com/mfussenegger/nvim-dap",
+})
+
+local dap = require("dap")
+
+vim.fn.sign_define("DapBreakpoint", {
+	text = "●",
+	texthl = "DiagnosticSignError",
+	linehl = "",
+	numhl = "",
+})
+
+vim.fn.sign_define("DapBreakpointCondition", {
+	text = "◆",
+	texthl = "DiagnosticSignWarn",
+	linehl = "",
+	numhl = "",
+})
+
+vim.fn.sign_define("DapLogPoint", {
+	text = "◆",
+	texthl = "DiagnosticSignInfo",
+	linehl = "",
+	numhl = "",
+})
+
+vim.fn.sign_define("DapStopped", {
+	text = "▶",
+	texthl = "DiagnosticSignHint",
+	linehl = "Visual",
+	numhl = "DiagnosticSignHint",
+})
+
+vim.fn.sign_define("DapBreakpointRejected", {
+	text = "○",
+	texthl = "DiagnosticSignError",
+	linehl = "",
+	numhl = "",
+})
+
+local function map(lhs, rhs, desc)
+	vim.keymap.set("n", lhs, rhs, { desc = "DAP: " .. desc, silent = true })
+end
+
+map("<leader>dc", dap.continue, "Continue")
+map("<leader>dt", dap.terminate, "Terminate")
+map("<leader>do", dap.step_over, "Step over")
+map("<leader>di", dap.step_into, "Step into")
+map("<leader>dO", dap.step_out, "Step out")
+map("<leader>db", dap.toggle_breakpoint, "Toggle breakpoint")
+map("<leader>dB", function()
+	dap.set_breakpoint(vim.fn.input("Breakpoint condition: "))
+end, "Set conditional breakpoint")
+map("<leader>dl", function()
+	dap.set_breakpoint(nil, nil, vim.fn.input("Log point message: "))
+end, "Set log point")
+map("<leader>dr", dap.repl.open, "Open REPL")
+map("<leader>dR", dap.run_last, "Run last")

--- a/.config/nvim/plugin/mason.lua
+++ b/.config/nvim/plugin/mason.lua
@@ -39,6 +39,7 @@ require("mason-tool-installer").setup({
 		"golines",
 		--debuggers
 		"delve",
+		"js-debug-adapter",
 		--linters
 		"revive", -- <--  for Go
 		"eslint_d", -- <-- for javascript/typescript

--- a/.config/nvim/plugin/mason.lua
+++ b/.config/nvim/plugin/mason.lua
@@ -37,6 +37,8 @@ require("mason-tool-installer").setup({
 		"gofumpt",
 		"goimports",
 		"golines",
+		--debuggers
+		"delve",
 		--linters
 		"revive", -- <--  for Go
 		"eslint_d", -- <-- for javascript/typescript


### PR DESCRIPTION
 ## Description

Adds a full Neovim DAP setup with core debugging keymaps, Go debugging through Delve, JavaScript/TypeScript Node debugging, Jest current-file debugging, inline virtual text values, and a focused DAP UI layout.

 ## Technical Changes

 - .config/nvim/nvim-pack-lock.json
         - Added lock entries for delve, nvim-dap, nvim-dap-go, nvim-dap-ui, nvim-dap-virtual-text, nvim-dap-vscode-js, and nvim-nio.

 - .config/nvim/plugin/dap.lua
         - Added nvim-dap package registration.
         - Added DAP signs for breakpoints, conditional breakpoints, log points, stopped state, and rejected breakpoints.
         - Added keymaps for start/continue, terminate, stepping, breakpoints, log points, REPL, and rerunning the last debug session.

 - .config/nvim/plugin/dap-go.lua
         - Added Go DAP support with nvim-dap-go.
         - Configured Delve with the dlv executable and initialization timeout.

 - .config/nvim/plugin/dap-js.lua
         - Added JavaScript and TypeScript debug configurations using the Mason js-debug server.
         - Added launch configs for current file debugging, file-directory debugging, Node process attachment, Jest current-file debugging, and npm start.
         - Registered configurations for JavaScript, TypeScript, JSX, and TSX filetypes.

 - .config/nvim/plugin/dap-virtual-text.lua
         - Added nvim-dap-virtual-text package registration.
         - Enabled inline debug values, changed variable highlighting, stop reason display, and reduced-noise variable rendering.

 - .config/nvim/plugin/dap-ui.lua
         - Added nvim-dap-ui and nvim-nio package registration.
         - Configured a left panel for scopes and breakpoints.
         - Configured a bottom panel for REPL and console.
         - Added keymaps for toggling the UI and evaluating expressions or selections.
         - Added listeners to open the UI when debugging starts and close it when debugging ends.

 - .config/nvim/plugin/mason.lua
         - Added delve and js-debug-adapter to the Mason tool installer list.
